### PR TITLE
Fixed Write(string) function

### DIFF
--- a/osu.Shared/Serialization/SerializationWriter.cs
+++ b/osu.Shared/Serialization/SerializationWriter.cs
@@ -12,11 +12,11 @@ namespace osu.Shared.Serialization
 
         public override void Write(string str)
         {
-            WriteObject(str);
             if (str == null)
                 Write((byte) TypeBytes.Null);
-            else {
-                Write((byte) TypeBytes.Null);
+            else
+            {
+                Write((byte) TypeBytes.String);
                 base.Write(str);
             }
         }


### PR DESCRIPTION
Function was writing string to BinaryWriter twice and with invalid TypeByte.